### PR TITLE
Update links to the repo

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -9,6 +9,6 @@ kind: frontend
 labextension_name: jupyterlab-codestral
 project_short_description: Codestral AI code completions for JupyterLab
 python_name: jupyterlab_codestral
-repository: https://github.com/jtpio/jupyterlab-codestral
+repository: https://github.com/jupyterlite/jupyterlab-codestral
 test: false
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 AI code completions and chat for JupyterLab, Notebook 7 and JupyterLite, powered by MistralAI ✨
 
-[a screencast showing the Codestral extension in JupyterLite]( https://github.com/jupyterlite/jupyterlab-codestral/assets/591645/855c4e3e-3a63-4868-8052-5c9909922c21)
+[a screencast showing the Codestral extension in JupyterLite](https://github.com/jupyterlite/jupyterlab-codestral/assets/591645/855c4e3e-3a63-4868-8052-5c9909922c21)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 AI code completions and chat for JupyterLab, Notebook 7 and JupyterLite, powered by MistralAI ✨
 
-[a screencast showing the Codestral extension in JupyterLite](https://github.com/jupyterlite/jupyterlab-codestral/assets/591645/b63a84de-32bf-449c-8b48-7d71494b88b9)
+[a screencast showing the Codestral extension in JupyterLite]( https://github.com/jupyterlite/jupyterlab-codestral/assets/591645/855c4e3e-3a63-4868-8052-5c9909922c21)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jupyterlab-codestral
 
 [![Github Actions Status](https://github.com/jupyterlite/jupyterlab-codestral/workflows/Build/badge.svg)](https://github.com/jupyterlite/jupyterlab-codestral/actions/workflows/build.yml)
-[![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jtpio.github.io/jupyterlab-codestral/lab/index.html)
+[![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jupyterlite.github.io/jupyterlab-codestral/lab/index.html)
 
 AI code completions and chat for JupyterLab, Notebook 7 and JupyterLite, powered by MistralAI ✨
 
@@ -20,7 +20,7 @@ AI code completions and chat for JupyterLab, Notebook 7 and JupyterLite, powered
 
 You can try the extension in your browser using JupyterLite:
 
-[![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jtpio.github.io/jupyterlab-codestral/lab/index.html)
+[![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jupyterlite.github.io/jupyterlab-codestral/lab/index.html)
 
 See the [Usage](#usage) section below for more information on how to provide your API key.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # jupyterlab-codestral
 
-[![Github Actions Status](https://github.com/jtpio/jupyterlab-codestral/workflows/Build/badge.svg)](https://github.com/jtpio/jupyterlab-codestral/actions/workflows/build.yml)
+[![Github Actions Status](https://github.com/jupyterlite/jupyterlab-codestral/workflows/Build/badge.svg)](https://github.com/jupyterlite/jupyterlab-codestral/actions/workflows/build.yml)
 [![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jtpio.github.io/jupyterlab-codestral/lab/index.html)
 
 AI code completions and chat for JupyterLab, Notebook 7 and JupyterLite, powered by MistralAI ✨
 
-[a screencast showing the Codestral extension in JupyterLite](https://github.com/jtpio/jupyterlab-codestral/assets/591645/b63a84de-32bf-449c-8b48-7d71494b88b9)
+[a screencast showing the Codestral extension in JupyterLite](https://github.com/jupyterlite/jupyterlab-codestral/assets/591645/b63a84de-32bf-449c-8b48-7d71494b88b9)
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
         "jupyterlab",
         "jupyterlab-extension"
     ],
-    "homepage": "https://github.com/jtpio/jupyterlab-codestral",
+    "homepage": "https://github.com/jupyterlite/jupyterlab-codestral",
     "bugs": {
-        "url": "https://github.com/jtpio/jupyterlab-codestral/issues"
+        "url": "https://github.com/jupyterlite/jupyterlab-codestral/issues"
     },
     "license": "BSD-3-Clause",
     "author": "Jeremy Tuloup",
@@ -24,7 +24,7 @@
     "style": "style/index.css",
     "repository": {
         "type": "git",
-        "url": "https://github.com/jtpio/jupyterlab-codestral.git"
+        "url": "https://github.com/jupyterlite/jupyterlab-codestral.git"
     },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
After the move to the https://github.com/jupyterlite org.