### PR TITLE
Refactoring AIProvider and handling errors

### DIFF
--- a/src/chat-handler.ts
+++ b/src/chat-handler.ts
@@ -16,6 +16,8 @@ import {
   mergeMessageRuns
 } from '@langchain/core/messages';
 import { UUID } from '@lumino/coreutils';
+import { getErrorMessage } from './llm-models';
+import { IAIProvider } from './token';
 
 export type ConnectionMessage = {
   type: 'connection';
@@ -25,14 +27,14 @@ export type ConnectionMessage = {
 export class ChatHandler extends ChatModel {
   constructor(options: ChatHandler.IOptions) {
     super(options);
-    this._provider = options.provider;
+    this._aiProvider = options.aiProvider;
+    this._aiProvider.modelChange.connect(() => {
+      this._errorMessage = this._aiProvider.chatError;
+    });
   }
 
   get provider(): BaseChatModel | null {
-    return this._provider;
-  }
-  set provider(provider: BaseChatModel | null) {
-    this._provider = provider;
+    return this._aiProvider.chatModel;
   }
 
   async sendMessage(message: INewMessage): Promise<boolean> {
@@ -46,10 +48,10 @@ export class ChatHandler extends ChatModel {
     };
     this.messageAdded(msg);
 
-    if (this._provider === null) {
+    if (this._aiProvider.chatModel === null) {
       const errorMsg: IChatMessage = {
         id: UUID.uuid4(),
-        body: `**${this.message ? this.message : this._defaultMessage}**`,
+        body: `**${this._errorMessage ? this._errorMessage : this._defaultErrorMessage}**`,
         sender: { username: 'ERROR' },
         time: Date.now(),
         type: 'msg'
@@ -69,14 +71,15 @@ export class ChatHandler extends ChatModel {
       })
     );
 
-    return this._provider
+    this.updateWriters([{ username: 'AI' }]);
+    return this._aiProvider.chatModel
       .invoke(messages)
       .then(response => {
         const content = response.content;
         const botMsg: IChatMessage = {
           id: UUID.uuid4(),
           body: content.toString(),
-          sender: { username: 'Bot' },
+          sender: { username: 'AI' },
           time: Date.now(),
           type: 'msg'
         };
@@ -85,9 +88,7 @@ export class ChatHandler extends ChatModel {
         return true;
       })
       .catch(reason => {
-        const error = reason.error.error.message ?? 'Error with the chat API';
-        console.log('REASON', error);
-        console.log('REASON', typeof error);
+        const error = getErrorMessage(this._aiProvider.name, reason);
         const errorMsg: IChatMessage = {
           id: UUID.uuid4(),
           body: `**${error}**`,
@@ -97,6 +98,9 @@ export class ChatHandler extends ChatModel {
         };
         this.messageAdded(errorMsg);
         return false;
+      })
+      .finally(() => {
+        this.updateWriters([]);
       });
   }
 
@@ -112,14 +116,14 @@ export class ChatHandler extends ChatModel {
     super.messageAdded(message);
   }
 
-  message: string = '';
-  private _provider: BaseChatModel | null;
+  private _aiProvider: IAIProvider;
+  private _errorMessage: string = '';
   private _history: IChatHistory = { messages: [] };
-  private _defaultMessage = 'AI provider not configured';
+  private _defaultErrorMessage = 'AI provider not configured';
 }
 
 export namespace ChatHandler {
   export interface IOptions extends ChatModel.IOptions {
-    provider: BaseChatModel | null;
+    aiProvider: IAIProvider;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,13 +41,8 @@ const chatPlugin: JupyterFrontEndPlugin<void> = {
     }
 
     const chatHandler = new ChatHandler({
-      provider: aiProvider.chatModel,
+      aiProvider: aiProvider,
       activeCellManager: activeCellManager
-    });
-
-    aiProvider.modelChange.connect(() => {
-      chatHandler.provider = aiProvider.chatModel;
-      chatHandler.message = aiProvider.chatError;
     });
 
     let sendWithShiftEnter = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ const chatPlugin: JupyterFrontEndPlugin<void> = {
 
     aiProvider.modelChange.connect(() => {
       chatHandler.provider = aiProvider.chatModel;
+      chatHandler.message = aiProvider.chatError;
     });
 
     let sendWithShiftEnter = false;

--- a/src/llm-models/base-completer.ts
+++ b/src/llm-models/base-completer.ts
@@ -3,6 +3,7 @@ import {
   IInlineCompletionContext
 } from '@jupyterlab/completer';
 import { LLM } from '@langchain/core/language_models/llms';
+import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 
 export interface IBaseCompleter {
   /**
@@ -17,4 +18,16 @@ export interface IBaseCompleter {
     request: CompletionHandler.IRequest,
     context: IInlineCompletionContext
   ): Promise<any>;
+}
+
+/**
+ * The namespace for the base completer.
+ */
+export namespace BaseCompleter {
+  /**
+   * The options for the constructor of a completer.
+   */
+  export interface IOptions {
+    settings: ReadonlyPartialJSONObject;
+  }
 }

--- a/src/llm-models/codestral-completer.ts
+++ b/src/llm-models/codestral-completer.ts
@@ -7,7 +7,7 @@ import { MistralAI } from '@langchain/mistralai';
 import { Throttler } from '@lumino/polling';
 import { CompletionRequest } from '@mistralai/mistralai';
 
-import { IBaseCompleter } from './base-completer';
+import { BaseCompleter, IBaseCompleter } from './base-completer';
 
 /*
  * The Mistral API has a rate limit of 1 request per second
@@ -15,11 +15,8 @@ import { IBaseCompleter } from './base-completer';
 const INTERVAL = 1000;
 
 export class CodestralCompleter implements IBaseCompleter {
-  constructor() {
-    this._mistralProvider = new MistralAI({
-      apiKey: 'TMP',
-      model: 'codestral-latest'
-    });
+  constructor(options: BaseCompleter.IOptions) {
+    this._mistralProvider = new MistralAI({ ...options.settings });
     this._throttler = new Throttler(async (data: CompletionRequest) => {
       const response = await this._mistralProvider.completionWithRetry(
         data,

--- a/src/llm-models/utils.ts
+++ b/src/llm-models/utils.ts
@@ -29,3 +29,13 @@ export function getChatModel(
   }
   return null;
 }
+
+/**
+ * Get the error message from provider.
+ */
+export function getErrorMessage(name: string, error: any): string {
+  if (name === 'MistralAI') {
+    return error.message;
+  }
+  return 'Unknown provider';
+}

--- a/src/llm-models/utils.ts
+++ b/src/llm-models/utils.ts
@@ -2,13 +2,17 @@ import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { ChatMistralAI } from '@langchain/mistralai';
 import { IBaseCompleter } from './base-completer';
 import { CodestralCompleter } from './codestral-completer';
+import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 
 /**
  * Get an LLM completer from the name.
  */
-export function getCompleter(name: string): IBaseCompleter | null {
+export function getCompleter(
+  name: string,
+  settings: ReadonlyPartialJSONObject
+): IBaseCompleter | null {
   if (name === 'MistralAI') {
-    return new CodestralCompleter();
+    return new CodestralCompleter({ settings });
   }
   return null;
 }
@@ -16,9 +20,12 @@ export function getCompleter(name: string): IBaseCompleter | null {
 /**
  * Get an LLM chat model from the name.
  */
-export function getChatModel(name: string): BaseChatModel | null {
+export function getChatModel(
+  name: string,
+  settings: ReadonlyPartialJSONObject
+): BaseChatModel | null {
   if (name === 'MistralAI') {
-    return new ChatMistralAI({ apiKey: 'TMP' });
+    return new ChatMistralAI({ ...settings });
   }
   return null;
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -9,6 +9,8 @@ export interface IAIProvider {
   completer: IBaseCompleter | null;
   chatModel: BaseChatModel | null;
   modelChange: ISignal<IAIProvider, void>;
+  chatError: string;
+  completerError: string;
 }
 
 export const IAIProvider = new Token<IAIProvider>(

--- a/src/token.ts
+++ b/src/token.ts
@@ -5,7 +5,7 @@ import { ISignal } from '@lumino/signaling';
 import { IBaseCompleter } from './llm-models';
 
 export interface IAIProvider {
-  name: string | null;
+  name: string;
   completer: IBaseCompleter | null;
   chatModel: BaseChatModel | null;
   modelChange: ISignal<IAIProvider, void>;


### PR DESCRIPTION
This PR is to prepare adding new providers, see https://github.com/jupyterlite/jupyterlab-codestral/issues/13#issuecomment-2456729648 for context.

### Changes

- The chat and completer providers are created every time a setting change, since some of them are not updating the config after init.
- The AIProvider is embedded in the chat handler
- If there is an error in the settings of the chat provider or while sending a message, the error message is displayed as a chat message.
  We may want a better way to display errors (notification, header in the chat...).


![Peek 2024-11-05 17-03](https://github.com/user-attachments/assets/7c213bb0-80da-49d5-85d4-5bbac53a0f2b)
